### PR TITLE
[refactor] handle error with converting errors to domain error

### DIFF
--- a/internal/core/domain/errors.go
+++ b/internal/core/domain/errors.go
@@ -1,0 +1,42 @@
+package domain
+
+import (
+	"errors"
+	"fmt"
+)
+
+type ErrorCode int
+
+const (
+	Unknown ErrorCode = iota
+	NotFound
+	Internal
+)
+
+func (e ErrorCode) String() string {
+	return [...]string{"Unknown", "NotFound", "Internal"}[e]
+}
+
+type DomainError struct {
+	Code  ErrorCode
+	Msg   string
+	Cause error
+}
+
+func (e *DomainError) Error() string {
+	return fmt.Sprintf("%s (code: %d)", e.Msg, e.Code)
+}
+
+func NewDomainError(msg string, code ErrorCode, cause error) *DomainError {
+	return &DomainError{
+		Code:  code,
+		Msg:   msg,
+		Cause: cause,
+	}
+}
+
+func IsDomainError(err error) (*DomainError, bool) {
+	var domainError *DomainError
+	ok := errors.As(err, &domainError)
+	return domainError, ok
+}

--- a/internal/core/ports/in/usecase/user_usecase.go
+++ b/internal/core/ports/in/usecase/user_usecase.go
@@ -14,8 +14,8 @@ func NewUserUsecase(repo repository.UserRepository) *UserUsecase {
 	return &UserUsecase{repo: repo}
 }
 
-func (u *UserUsecase) CreateUser(account *domain.User, ctx context.Context) (*domain.User, error) {
-	return u.repo.CreateUser(account, ctx)
+func (u *UserUsecase) CreateUser(user *domain.User, ctx context.Context) (*domain.User, error) {
+	return u.repo.CreateUser(user, ctx)
 }
 
 func (u *UserUsecase) GetUserByID(id int64, ctx context.Context) (*domain.User, error) {

--- a/internal/core/ports/in/usecase/user_usecase.go
+++ b/internal/core/ports/in/usecase/user_usecase.go
@@ -19,7 +19,7 @@ func (u *UserUsecase) GetUserByOAuthProviderAndEmailOrCreateIfAbsent(
 	email string,
 	user *domain.User,
 	ctx context.Context,
-) (*domain.User, error) {
+) (*domain.User, *domain.DomainError) {
 	userFromDb, err := u.GetUserByOAuthProviderAndEmail(oAuthProvider, email, ctx)
 	if err != nil {
 		if domainErr, ok := domain.IsDomainError(err); ok {
@@ -36,18 +36,18 @@ func (u *UserUsecase) GetUserByOAuthProviderAndEmailOrCreateIfAbsent(
 	return userFromDb, nil
 }
 
-func (u *UserUsecase) CreateUser(user *domain.User, ctx context.Context) (*domain.User, error) {
+func (u *UserUsecase) CreateUser(user *domain.User, ctx context.Context) (*domain.User, *domain.DomainError) {
 	return u.repo.CreateUser(user, ctx)
 }
 
-func (u *UserUsecase) GetUserByID(id int64, ctx context.Context) (*domain.User, error) {
+func (u *UserUsecase) GetUserByID(id int64, ctx context.Context) (*domain.User, *domain.DomainError) {
 	return u.repo.GetUserByID(id, ctx)
 }
 
-func (u *UserUsecase) GetUserByOAuthProviderAndEmail(oAuthProvider string, email string, ctx context.Context) (*domain.User, error) {
+func (u *UserUsecase) GetUserByOAuthProviderAndEmail(oAuthProvider string, email string, ctx context.Context) (*domain.User, *domain.DomainError) {
 	return u.repo.GetUserByOAuthProviderAndEmail(oAuthProvider, email, ctx)
 }
 
-func (u *UserUsecase) DeleteUser(id int64, ctx context.Context) error {
+func (u *UserUsecase) DeleteUser(id int64, ctx context.Context) *domain.DomainError {
 	return u.repo.DeleteUser(id, ctx)
 }

--- a/internal/core/ports/out/repository/user_repository.go
+++ b/internal/core/ports/out/repository/user_repository.go
@@ -6,8 +6,8 @@ import (
 )
 
 type UserRepository interface {
-	CreateUser(account *domain.User, ctx context.Context) (*domain.User, error)
-	GetUserByID(id int64, ctx context.Context) (*domain.User, error)
-	GetUserByOAuthProviderAndEmail(oAuthProvider string, email string, ctx context.Context) (*domain.User, error)
-	DeleteUser(id int64, ctx context.Context) error
+	CreateUser(account *domain.User, ctx context.Context) (*domain.User, *domain.DomainError)
+	GetUserByID(id int64, ctx context.Context) (*domain.User, *domain.DomainError)
+	GetUserByOAuthProviderAndEmail(oAuthProvider string, email string, ctx context.Context) (*domain.User, *domain.DomainError)
+	DeleteUser(id int64, ctx context.Context) *domain.DomainError
 }


### PR DESCRIPTION
## Changes
- Refactored error handling with adding `DomainError`
  - `DomainError` contains `ErrorCode`, `Msg`, `Cause` for better logging.
  - Out adapters return only `DomainError` to the port.
  - In adpaters handle DomainError and use it for logging and building response.
- Applied refactored `DomainError` to `UserUsecase`.