### PR TITLE
[feat] Respond Google callback uri with body not 307

### DIFF
--- a/internal/adapters/in/api/dto/user.go
+++ b/internal/adapters/in/api/dto/user.go
@@ -1,5 +1,9 @@
 package dto
 
+type RedirectUriResponse struct {
+	RedirectUri string `json:"redirect_uri"`
+}
+
 type GoogleUserResponse struct {
 	ID      string `json:"id"`
 	Email   string `json:"email"`

--- a/internal/adapters/in/api/user_handler.go
+++ b/internal/adapters/in/api/user_handler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	"golang.org/x/oauth2"
-	"net/http"
 )
 
 type UserHandler struct {
@@ -30,7 +29,7 @@ func NewUserHandler(
 	}
 }
 
-func (h *UserHandler) RedirectLoginGoogle(c *fiber.Ctx) error {
+func (h *UserHandler) GetRedirectLoginGoogle(c *fiber.Ctx) error {
 	session, err := h.session.Store.Get(c)
 	if err != nil {
 		return err
@@ -44,7 +43,7 @@ func (h *UserHandler) RedirectLoginGoogle(c *fiber.Ctx) error {
 
 	authCodeURL := h.oAuthConfig.Google.AuthCodeURL(state, oauth2.AccessTypeOffline)
 
-	return c.Redirect(authCodeURL, http.StatusTemporaryRedirect)
+	return c.JSON(&dto.RedirectUriResponse{RedirectUri: authCodeURL})
 }
 
 func (h *UserHandler) CallbackGoogle(c *fiber.Ctx) error {

--- a/internal/framework/app.go
+++ b/internal/framework/app.go
@@ -16,6 +16,6 @@ func NewApp(
 }
 
 func SetupRoutes(app *fiber.App, handler *api.UserHandler) {
-	app.Get("/api/v1/auth/login", handler.RedirectLoginGoogle)
+	app.Get("/api/v1/auth/login", handler.GetRedirectLoginGoogle)
 	app.Get("/api/v1/auth/callback", handler.CallbackGoogle)
 }


### PR DESCRIPTION
## Chages
- I found that on Safari, Set-Cookie with HTTP status code 307 is not available. It does not show Set-Cookie in the developer tool either.
- The workaround was making the server respond with status code 200 and a response body containing the `redirect_uri`, and having the client perform the redirect itself using this response.
- Therefore, I’ve changed the response method of the Google `redirect_uri` to status code 200 with a response body that includes the `redirect_uri`.