### PR TITLE
[feat] Dynamic redirect_uri for oauth login

### DIFF
--- a/internal/adapters/in/api/user_handler.go
+++ b/internal/adapters/in/api/user_handler.go
@@ -30,8 +30,15 @@ func NewUserHandler(
 
 func (h *UserHandler) GetRedirectLoginGoogle(c *fiber.Ctx) error {
 	state := uuid.NewString()
+	dynamicRedirectUri := c.Query("redirect_uri")
+	if dynamicRedirectUri == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "missing redirect_uri"})
+	}
 
-	authCodeURL := h.oAuthConfig.Google.AuthCodeURL(state, oauth2.AccessTypeOffline)
+	oAuthConfig := *h.oAuthConfig.Google
+	oAuthConfig.RedirectURL = dynamicRedirectUri
+
+	authCodeURL := oAuthConfig.AuthCodeURL(state, oauth2.AccessTypeOffline)
 
 	return c.JSON(&dto.RedirectUriResponse{RedirectUri: authCodeURL})
 }


### PR DESCRIPTION
## Changes
- Resolves #15 
- Get url encoded redirect_uri through query parameter
- Copy original `oAuthConfig`
- Alter `redirect_uri` with query parameter